### PR TITLE
Updated canvas dependency to v2.6.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function (options) {
   const headerHeight = (options.header || {}).height || 0;
   const canvasWidth = options.width * options.imageWidth + (options.width - 1) * (options.spacing);
   const canvasHeight = headerHeight  + options.height * options.imageHeight + (options.height - 1) * (options.spacing) + (options.textStyle.height || 200);
-  const canvas = new Canvas(canvasWidth, canvasHeight);
+  const canvas = Canvas.createCanvas(canvasWidth, canvasHeight);
 
   const ctx = canvas.getContext("2d");
   ctx.fillStyle = options.backgroundColor;

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 const Promise  = require("bluebird");
 const request  = require("request");
-const Canvas   = require("canvas");
 const fs       = Promise.promisifyAll(require("fs"));
+const { createCanvas, Canvas, Image } = require("canvas");
 
 function downloadPhoto (uri) {
   return new Promise((resolve, reject) => {
@@ -86,7 +86,7 @@ module.exports = function (options) {
   const headerHeight = (options.header || {}).height || 0;
   const canvasWidth = options.width * options.imageWidth + (options.width - 1) * (options.spacing);
   const canvasHeight = headerHeight  + options.height * options.imageHeight + (options.height - 1) * (options.spacing) + (options.textStyle.height || 200);
-  const canvas = Canvas.createCanvas(canvasWidth, canvasHeight);
+  const canvas = createCanvas(canvasWidth, canvasHeight);
 
   const ctx = canvas.getContext("2d");
   ctx.fillStyle = options.backgroundColor;
@@ -103,7 +103,7 @@ module.exports = function (options) {
     .each((photoBuffer, i) => {
       if (i >= maxImages) return;
 
-      const img = new Canvas.Image();
+      const img = new Image();
       img.src = photoBuffer;
 
       if ((options.header || {}).image) { // only for header

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/classdojo/photo-collage#readme",
   "dependencies": {
     "bluebird": "^3.3.5",
-    "canvas": "^1.3.15",
+    "canvas": "^2.6.1",
     "request": "^2.72.0"
   },
   "devDependencies": {


### PR DESCRIPTION
From [this canvas wiki page](https://github.com/Automattic/node-canvas/wiki/Installation:-Prebuilt):
> Canvas 2.x uses prebuilds by default...

This update should bypass all the nonsense of dealing with `node-gyp`.

I followed the official upgrade instructions [found here](https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md#200). Note that this change would break support for Node.js < v6.x